### PR TITLE
readme: Arch Linux AUR packages moved to this fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ The following table shows the relation between the swaylock-effect and swaylock 
 ### From Packages
 
 * Alpine Linux: [swaylock-effects](https://pkgs.alpinelinux.org/packages?name=swaylock-effects)
+* Arch Linux (AUR): [swaylock-effects](https://aur.archlinux.org/packages/swaylock-effects/) / [swaylock-effects-git](https://aur.archlinux.org/packages/swaylock-effects-git/)
 
 The original [mortie/swaylock-effects](https://github.com/mortie/swaylock-effects) (now unmaintained)
 has been packaged for:
 
-* Arch Linux (AUR): [swaylock-effects-git](https://aur.archlinux.org/packages/swaylock-effects-git/)
 * Fedora (Copr): [swaylock-effects](https://copr.fedorainfracloud.org/coprs/eddsalkield/swaylock-effects/)
   (thanks to Edd Salkield)
 * FreeBSD: [swaylock-effects](https://www.freshports.org/x11/swaylock-effects/)


### PR DESCRIPTION
Both Arch Linux AUR packages changed their upstream to this fork. This PR updates the readme accordingly.