### PR TITLE
Updated meson build file to reflect new (i.e. meson version > 0.46) way of including openmp dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,14 +17,6 @@ add_project_arguments(
 		'-Wno-unused-result',
 		'-Wundef',
 		'-Wvla',
-		'-fopenmp',
-	],
-	language: 'c',
-)
-
-add_project_link_arguments(
-	[
-		'-fopenmp',
 	],
 	language: 'c',
 )
@@ -53,6 +45,7 @@ wayland_protos = dependency('wayland-protocols', version: '>=1.25', fallback: 'w
 wayland_scanner = dependency('wayland-scanner', version: '>=1.15.0')
 xkbcommon = dependency('xkbcommon')
 cairo = dependency('cairo')
+omp = dependency('openmp')
 gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
 bash_comp = dependency('bash-completion', required: false)
 fish_comp = dependency('fish', required: false)
@@ -133,6 +126,7 @@ dependencies = [
 	dl,
 	xkbcommon,
 	wayland_client,
+	omp
 ]
 
 sources = [


### PR DESCRIPTION
Since version 0.46 of Meson, released 23 April 2018, you can [directly include](https://mesonbuild.com/Release-notes-for-0-46-0.html#addition-of-openmp-dependency) a dependency on OpenMP, as opposed to manually adding the compiler flags. This results in fewer lines of code, notifies you if there's something wrong with your OpenMP installation (for instance, on my machine, with Clang, I needed to separately install a package for `omp.h`; the existing solution executed `meson setup build` without errors, but failed to compile, whilst this proposed solution catches any problems at the setup stage) and is more portable (for instance, the `-fopenmp` flag is deprecated for the [Intel compiler](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/compiler-reference/compiler-options/offload-openmp-and-parallel-processing-options/fopenmp.html)).