### PR TITLE
Fix underdesirable replay of fade effect on surface recreation

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -76,6 +76,7 @@ struct swaylock_args {
 	char *timestr;
 	char *datestr;
 	uint32_t fade_in;
+	bool allow_fade;
 	bool password_submit_on_touch;
 	uint32_t password_grace_period;
 	bool password_grace_no_mouse;


### PR DESCRIPTION
Addresses #12 

When a surface is created, a fade in effect occurs (if specified in the arguments). This animation is desirable when swaylock is initially run, however, it is undesirable after it is run. 

For example, on a running swaylock process, if the surface is destroyed when a laptop is closed, the surface must be recreated when the lid is reopened and the output turns on again. During this recreation, the fade in animation replays, temporarily showing the working state of the machine long after swaylock was initially run.

This has obvious security and privacy concerns - anyone can see the working state of a machine by closing and reopening a laptop lid, or by hooking up another monitor and forcing another surface to be created. This PR is a simple attempt to fix that by only allowing the fade animation to occur in a small time window immediately after swaylock starts. 

I was only able to test on my machine - let me know what you think.  
