### PR TITLE
Add support for 24-bit RGB and BGR pixel formats

### DIFF
--- a/background-image.c
+++ b/background-image.c
@@ -91,6 +91,39 @@ void cairo_rgb24_from_bgrx1010102_le(unsigned char *buf, int width, int height, 
 	}
 }
 
+// Cairo RGB24 uses 32 bits per pixel, as XRGB, in native endianness.
+// BGR888 uses 24 bits per pixel, as BGR, little endian.
+// 24-bit BGR format, [23:0] B:G:R little endian (From wayland-client-protocol.h)
+void cairo_rgb24_from_bgr888_le(unsigned char *buf, int width, int height, int stride) {
+	for (int y = 0; y < height; ++y) {
+		// Row from back to front to avoid overwriting data.
+		for (int x = width-1; x >= 0; --x) {
+			// 24 bits = 3 bytes, 32 bits = 4 bytes
+			unsigned char *srcpix = buf + y * stride + x * 3;
+			unsigned char *dstpix = buf + y * stride + x * 4;
+
+			*(uint32_t *)dstpix = 0 |
+				(uint32_t)srcpix[0] << 16 |
+				(uint32_t)srcpix[1] << 8 |
+				(uint32_t)srcpix[2];
+		}
+	}
+}
+
+// Swap red and blue values in Cairo RGB24
+void cairo_rgb24_swap_rb(unsigned char *buf, int width, int height, int stride) {
+	for (int y = 0; y < height; ++y) {
+		for (int x = 0; x < width; ++x) {
+			unsigned char *pix = buf + y * stride + x * 4;
+
+			*(uint32_t *)pix = 0 |
+				(uint32_t)pix[0] << 16 |
+				(uint32_t)pix[1] << 8 |
+				(uint32_t)pix[2];
+		}
+	}
+}
+
 enum background_mode parse_background_mode(const char *mode) {
 	if (strcmp(mode, "stretch") == 0) {
 		return BACKGROUND_MODE_STRETCH;
@@ -262,6 +295,23 @@ cairo_surface_t *load_background_from_buffer(void *buf, uint32_t format,
 				cairo_image_surface_get_width(image),
 				cairo_image_surface_get_height(image),
 				cairo_image_surface_get_stride(image));
+		break;
+	case WL_SHM_FORMAT_BGR888:
+	case WL_SHM_FORMAT_RGB888:
+			cairo_rgb24_from_bgr888_le(
+					cairo_image_surface_get_data(image),
+					cairo_image_surface_get_width(image),
+					cairo_image_surface_get_height(image),
+					cairo_image_surface_get_stride(image)
+					);
+			if (format == WL_SHM_FORMAT_RGB888) {
+				cairo_rgb24_swap_rb(
+						cairo_image_surface_get_data(image),
+						cairo_image_surface_get_width(image),
+						cairo_image_surface_get_height(image),
+						cairo_image_surface_get_stride(image)
+						);
+			}
 		break;
 	default:
 		swaylock_log(LOG_ERROR,


### PR DESCRIPTION
Adds support for the following pixel formats:

```
/**
 * 24-bit RGB format, [23:0] R:G:B little endian
 */
WL_SHM_FORMAT_RGB888 = 0x34324752,
/**
 * 24-bit BGR format, [23:0] B:G:R little endian
 */
WL_SHM_FORMAT_BGR888 = 0x34324742,
```

Without this, screenshots appear with the image squeezed in the left $3/4$ of the screen with the colors messed up when using those pixel formats, which sounds similar to this description from #11:

> The issue is simply that 1/3 of the screen will be blank when `--screenshot` is passed and the screenshot will be fit inside the remaining 2/3, which is counterintuitive.