### PR TITLE
Reinstantiate `-t` to be used as shorthand for `--trace`

### DIFF
--- a/completions/zsh/_swaylock
+++ b/completions/zsh/_swaylock
@@ -55,5 +55,5 @@ _arguments -s \
 	'(--text-color)'--text-color'[Sets the color of the text]:color:' \
 	'(--text-ver-color)'--text-ver-color'[Sets the color of the text when verifying]:color:' \
 	'(--text-wrong-color)'--text-wrong-color'[Sets the color of the text when invalid]:color:' \
-	'(--tiling -t)'{--tiling,-t}'[Same as --scaling=tile]' \
+	'(--tiling -T)'{--tiling,-T}'[Same as --scaling=tile]' \
 	'(--version -v)'{--version,-v}'[Show the version number and quit]'

--- a/main.c
+++ b/main.c
@@ -104,7 +104,7 @@ static const char *parse_screen_pos_pair(const char *str, char delim,
 }
 
 static const char *parse_constant(const char *str1, const char *str2) {
-	size_t len = strlen(str2); 
+	size_t len = strlen(str2);
 	if (strncmp(str1, str2, len) == 0) {
 		return str1 + len;
 	} else {
@@ -944,7 +944,6 @@ enum line_mode {
 static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		enum line_mode *line_mode, char **config_path) {
 	enum long_option_codes {
-		LO_TRACE,
 		LO_BS_HL_COLOR = 256,
 		LO_CAPS_LOCK_BS_HL_COLOR,
 		LO_CAPS_LOCK_KEY_HL_COLOR,
@@ -1003,7 +1002,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"config", required_argument, NULL, 'C'},
 		{"color", required_argument, NULL, 'c'},
 		{"debug", no_argument, NULL, 'd'},
-		{"trace", no_argument, NULL, LO_TRACE},
+		{"trace", no_argument, NULL, 't'},
 		{"ignore-empty-password", no_argument, NULL, 'e'},
 		{"daemonize", no_argument, NULL, 'f'},
 		{"help", no_argument, NULL, 'h'},
@@ -1014,7 +1013,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"line-uses-inside", no_argument, NULL, 'n'},
 		{"line-uses-ring", no_argument, NULL, 'r'},
 		{"scaling", required_argument, NULL, 's'},
-		{"tiling", no_argument, NULL, 't'},
+		{"tiling", no_argument, NULL, 'T'},
 		{"no-unlock-indicator", no_argument, NULL, 'u'},
 		{"show-keyboard-layout", no_argument, NULL, 'k'},
 		{"hide-keyboard-layout", no_argument, NULL, 'K'},
@@ -1118,7 +1117,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Show the current Caps Lock state also on the indicator.\n"
 		"  -s, --scaling <mode>             "
 			"Image scaling mode: stretch, fill, fit, center, tile, solid_color.\n"
-		"  -t, --tiling                     "
+		"  -T, --tiling                     "
 			"Same as --scaling=tile.\n"
 		"  -u, --no-unlock-indicator        "
 			"Disable the unlock indicator.\n"
@@ -1254,7 +1253,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		case 'd':
 			swaylock_log_init(LOG_DEBUG);
 			break;
-		case LO_TRACE:
+		case 't':
 			swaylock_log_init(LOG_TRACE);
 			break;
 		case 'e':

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -103,7 +103,7 @@ Locks your Wayland session.
 	_solid\_color_. Use _solid\_color_ to display only the background color, even
 	if a background image is specified.
 
-*-t, --tiling*
+*-T, --tiling*
 	Same as --scaling=tile.
 
 *-c, --color* <rrggbb[aa]>


### PR DESCRIPTION
According to the help text `-t` is used as short-hand to enable `--trace`, while `-t` previously used for `--tiling` ended up being renamed to `-T` in the `option` parser but not in the switch-case in 323a48b ("fix screenshot logic, and add tracing"), resulting in `-t` to do nothing as the trace option was also using a zero-based long-option value rather than the character literal `'t'`.  Fix that, as well as the manual.