### PR TITLE
Try to fix red screen even through Swaylock exit normally.

### DIFF
--- a/main.c
+++ b/main.c
@@ -1980,6 +1980,7 @@ int main(int argc, char **argv) {
 	}
 	if (state.ext_session_lock_v1) {
 		ext_session_lock_v1_unlock_and_destroy(state.ext_session_lock_v1);
+		wl_display_roundtrip(state.display);
 		wl_display_flush(state.display);
 	}
 


### PR DESCRIPTION
Seems like if Swaylock exits before Wayland handles `ext_session_lock_v1_unlock_and_destroy` and free the `state` then Wayland may treat this as a `crash` then cause `Red Screen`.